### PR TITLE
corpus: update seed corpus

### DIFF
--- a/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/0b3dad204067dc80
+++ b/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/0b3dad204067dc80
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("LNDF00")

--- a/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/2c24017729a93368
+++ b/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/2c24017729a93368
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("LNDFU0")

--- a/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/a3a0037ee8cd09f1
+++ b/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/a3a0037ee8cd09f1
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("LN0000")

--- a/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/aac6c02daf24bf42
+++ b/seed_corpus/parser/testdata/fuzz/FuzzParseComplex/aac6c02daf24bf42
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("LND000")

--- a/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/14e37a358cfd004a
+++ b/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/14e37a358cfd004a
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("\xee\x94\xf1")

--- a/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/18c6665ca7eefbfa
+++ b/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/18c6665ca7eefbfa
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("0000000000\xff00000")

--- a/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/1d1a6a34177c6ee2
+++ b/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/1d1a6a34177c6ee2
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("000000000\x80000000")

--- a/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/8c5cda16ad706108
+++ b/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/8c5cda16ad706108
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("000\x800000")

--- a/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/90ece2e0900f94ad
+++ b/seed_corpus/stringutils/testdata/fuzz/FuzzUnSafeReverseString/90ece2e0900f94ad
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("00000000")


### PR DESCRIPTION
ref: https://github.com/go-continuous-fuzz/go-continuous-fuzz/pull/26#discussion_r2141825434

Removed seed corpus for crash-causing targets (`FuzzParseComplex` and `FuzzUnSafeReverseString`) since they had already achieved maximum coverage before crashing. This helps avoid flakiness in CI.
