### PR TITLE
Add fuzzing example to trigger OOM crash 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ A minimal Go repository demonstrating fuzz testing techniques and integration wi
 
 - **parser**: Contains functions for parsing and evaluating expressions.
 - **stringutils**: Provides string manipulation utilities.
+- **tree**: Provides binary tree building utilities.
 
 Each package includes:
 
 - One "safe" function that is robust against crashes during fuzzing.
 - One "unsafe" function that may crash or behave unexpectedly when fuzzed.
 - Corresponding fuzz tests in their respective `*_test.go` files.
+
+**NOTE**: The **tree** package contains only one function, which is an "unsafe" function that may crash or behave unexpectedly when fuzzed due to an out-of-memory (OOM) error.

--- a/seed_corpus/tree/testdata/fuzz/FuzzBuildTree/319194200cbebc1b
+++ b/seed_corpus/tree/testdata/fuzz/FuzzBuildTree/319194200cbebc1b
@@ -1,0 +1,2 @@
+go test fuzz v1
+int(1)

--- a/seed_corpus/tree/testdata/fuzz/FuzzBuildTree/cb392020cdffed46
+++ b/seed_corpus/tree/testdata/fuzz/FuzzBuildTree/cb392020cdffed46
@@ -1,0 +1,2 @@
+go test fuzz v1
+int(-53)

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -1,0 +1,22 @@
+package tree
+
+// TreeNode represents a node in a binary tree with integer values.
+type TreeNode struct {
+	Left  *TreeNode
+	Right *TreeNode
+	Value int
+}
+
+// BuildTree creates a complete binary tree of the specified depth.
+// Each node's Value is set to the current depth. Returns nil if the depth is
+// not positive.
+func BuildTree(depth int) *TreeNode {
+	if depth <= 0 {
+		return nil
+	}
+	return &TreeNode{
+		Left:  BuildTree(depth - 1),
+		Right: BuildTree(depth - 1),
+		Value: depth,
+	}
+}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -1,0 +1,10 @@
+package tree
+
+import "testing"
+
+// FuzzBuildTree fuzzes the BuildTree function.
+func FuzzBuildTree(f *testing.F) {
+	f.Fuzz(func(t *testing.T, depth int) {
+		_ = BuildTree(depth)
+	})
+}


### PR DESCRIPTION
ref: https://github.com/go-continuous-fuzz/go-continuous-fuzz/issues/30

This PR adds the `BuildTree` function and its fuzz target, which triggers an OOM crash when the input depth is greater than 27. It will be used in our e2e tests to ensure that our project can detect and report such crashes correctly without blocking or stopping other workers.